### PR TITLE
Additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Main config
 - `ADDITIONAL_MESSAGE (str | int)`: The message to display after a user recieved a file, set to 0 to disable.
 - `START_MESSAGE (str | int)`: a start message.
 - `AUTO_DELETE_MESSAGE (str | int)`: an auto delete messages, {} is the amount of minutes.
+- `INVALID_LINK_MESSAGE (str | int)`: The message to display when a file link is invalid.
+- `FILE_DOES_NOT_EXIST (str | int)`: The message to display when a file does not exists from codexbotz links.
 
 - `AUTO_DELETE_SECONDS (int)`: auto deletion in minutes, is set as {} of AUTO_DELETE_MESSAGE.
 - `GLOBAL_MODE (bool)`: toggle everyone to generate a file link.

--- a/bot/options.py
+++ b/bot/options.py
@@ -14,6 +14,9 @@ class SettingsModel(BaseModel):
         ADDITIONAL_MESSAGE (str | int): The message to display after a user recieved a file, set to 0 to disable.
         USER_REPLY_TEXT (str | int): The text to reply to a user.
         AUTO_DELETE_MESSAGE (str | int): The message to display when a file is deleted.
+        INVALID_LINK_MESSAGE (str | int): The message to display when a file link is invalid.
+        FILE_DOES_NOT_EXIST (str | int): The message to display when a file does not exists from codexbotz links.
+
         AUTO_DELETE_SECONDS (int): The number of seconds to wait before deleting a file, set to 0 to disable.
         GLOBAL_MODE (bool): Whether the bot is in global mode.
         BACKUP_FILES (bool): Whether to backup files.
@@ -25,6 +28,9 @@ class SettingsModel(BaseModel):
     ADDITIONAL_MESSAGE: str | int = 0
     USER_REPLY_TEXT: str | int = "idk"
     AUTO_DELETE_MESSAGE: str | int = "This file(s) will be deleted within {} minutes"
+    INVALID_LINK_MESSAGE: str | int = "Attempted to resolve link: Got invalid link."
+    FILE_DOES_NOT_EXIST: str | int = "Attempted to fetch files: Does not exist."
+
     AUTO_DELETE_SECONDS: int = 300
     GLOBAL_MODE: bool = False
     BACKUP_FILES: bool = True

--- a/bot/plugins/base/start.py
+++ b/bot/plugins/base/start.py
@@ -125,7 +125,11 @@ async def file_start(
                 backup_channel=config.BACKUP_CHANNEL,
             )
         except (DataValidationError, IndexError):
-            await message.reply(text="Attempted to resolve link: Got invalid link.")
+            await PyroHelper.option_message(
+                client=client,
+                message=message,
+                option_key=options.settings.INVALID_LINK_MESSAGE,
+            )
             return message.stop_propagation()
 
         send_files = await FileSender.codexbotz(
@@ -136,7 +140,11 @@ async def file_start(
             protect_content=config.PROTECT_CONTENT,
         )
         if not send_files:
-            await message.reply(text="Attempted to fetch files: Does not exist.")
+            await PyroHelper.option_message(
+                client=client,
+                message=message,
+                option_key=options.settings.FILE_DOES_NOT_EXIST,
+            )
             return message.stop_propagation()
     else:
         file_origin = file_document["file_origin"]


### PR DESCRIPTION
`INVALID_LINK_MESSAGE (str | int)`: The message to display when a file link is invalid.

`FILE_DOES_NOT_EXIST (str | int)`: The message to display when a file does not exists from codexbotz links.