### PR TITLE
Fix: CUSTOM_CAPTION=0 stripping original file captions

### DIFF
--- a/bot/utilities/pyrotools/file_resolver.py
+++ b/bot/utilities/pyrotools/file_resolver.py
@@ -67,13 +67,19 @@ class SendMedia:
             UnsupportedFileError: If the file type is unsupported.
         """
 
-        caption = "" if options.settings.CUSTOM_CAPTION == 0 else str(options.settings.CUSTOM_CAPTION)
+        custom_caption = options.settings.CUSTOM_CAPTION
         if options.settings.BACKUP_FILES:
             get_file = await client.get_messages(chat_id=file_origin, message_ids=file_data.message_id)
             if not getattr(get_file, "empty", False):
+                copy_kwargs: dict[str, Any] = {
+                    "chat_id": chat_id,
+                    "protect_content": protect_content,
+                }
+                if custom_caption != 0:
+                    copy_kwargs["caption"] = str(custom_caption)
                 return cast(
                     "Message",
-                    await get_file.copy(chat_id=chat_id, caption=caption, protect_content=protect_content),  # pyright: ignore[reportCallIssue]
+                    await get_file.copy(**copy_kwargs),  # pyright: ignore[reportCallIssue]
                 )
 
         file_type_data = FileId.decode(file_id=file_data.file_id)


### PR DESCRIPTION
## Bug

When `CUSTOM_CAPTION` is set to `0` (disabled/default), the `send_media` method in `file_resolver.py` was passing `caption=""` to `.copy()`, which **overwrites the original caption** with an empty string. This means any file sent with a caption (e.g., an image with descriptive text) would lose its caption when retrieved via a bot link.

## Fix

When `CUSTOM_CAPTION == 0`, the `caption` kwarg is no longer passed to `.copy()`, allowing Pyrogram to preserve the **original caption** from the backed-up message. When `CUSTOM_CAPTION` is set to a non-zero string, it continues to override as intended.